### PR TITLE
isunity typo error (js version3)

### DIFF
--- a/version3/js/fp12.js
+++ b/version3/js/fp12.js
@@ -60,7 +60,7 @@ var FP12 = function(ctx) {
         /* test x==1 ? */
         isunity: function() {
             var one = new ctx.FP4(1);
-            return (this.a.equals(one) && this.b.iszilch() && this.b.iszilch());
+            return (this.a.equals(one) && this.b.iszilch() && this.c.iszilch());
         },
 
 


### PR DESCRIPTION
isunity method was comparing this.b twice instead of this.b with this.c